### PR TITLE
Only log read message error when in verbose mode

### DIFF
--- a/godet.go
+++ b/godet.go
@@ -412,7 +412,10 @@ loop:
 		default:
 			_, bytes, err := remote.socket().ReadMessage()
 			if err != nil {
-				log.Println("read message:", err)
+				if remote.verbose {
+					log.Println("read message:", err)
+				}
+
 				if permanentError(err) {
 					break loop
 				}


### PR DESCRIPTION
When opening a new tab, it switches the websocket connection to a new location, but not closing the previous connection. This is all fine, because the goroutine breaks its loop, so no leakage.

.. but it does print a rather annoying message, even when verbosity is false
At line 415 in godet.go
https://github.com/raff/godet/blob/master/godet.go#L415

This pull request resolves that annoyance.
