### PR TITLE
adds SetDeviceMetricsOverride

### DIFF
--- a/examples/mobile.go
+++ b/examples/mobile.go
@@ -1,0 +1,60 @@
+// +build ignore
+
+package main
+
+import "fmt"
+import "time"
+
+import "github.com/JonathanMH/godet"
+
+func main() {
+	// connect to Chrome instance
+	remote, _ := godet.Connect("localhost:9222", true)
+
+	// disconnect when done
+	defer remote.Close()
+
+	// get browser and protocol version
+	version, _ := remote.Version()
+	fmt.Println(version)
+
+	// install some callbacks
+	remote.CallbackEvent(godet.EventClosed, func(params godet.Params) {
+		fmt.Println("RemoteDebugger connection terminated.")
+	})
+
+	remote.CallbackEvent("Network.requestWillBeSent", func(params godet.Params) {
+		fmt.Println("requestWillBeSent",
+			params["type"],
+			params["documentURL"],
+			params["request"].(map[string]interface{})["url"])
+	})
+
+	remote.CallbackEvent("Network.responseReceived", func(params godet.Params) {
+		fmt.Println("responseReceived",
+			params["type"],
+			params["response"].(map[string]interface{})["url"])
+	})
+
+	remote.CallbackEvent("Log.entryAdded", func(params godet.Params) {
+		entry := params["entry"].(map[string]interface{})
+		fmt.Println("LOG", entry["type"], entry["level"], entry["text"])
+	})
+
+	// enable event processing
+	remote.RuntimeEvents(true)
+	remote.NetworkEvents(true)
+	remote.PageEvents(true)
+	remote.DOMEvents(true)
+	remote.LogEvents(true)
+
+	// create new tab
+	tab, _ := remote.NewTab("https://gegenwind.dk") // google.com is wonky
+
+  remote.SetVisibleSize(375,667) // iPhone 7
+  remote.SetDeviceMetricsOverride(375,667,3,true,false) // iPhone 7
+
+	time.Sleep(time.Second * 3)
+	// take a screenshot
+	_ = remote.SaveScreenshot("mobile.png", 0644, 0, true)
+}

--- a/godet.go
+++ b/godet.go
@@ -1005,6 +1005,19 @@ func (remote *RemoteDebugger) SetVisibleSize(width, height int) error {
 	return err
 }
 
+// SetDeviceMetricsOverride sets mobile and fitWindow on top of device dimensions
+// Can be used to produce screenshots of mobile viewports.
+func (remote *RemoteDebugger) SetDeviceMetricsOverride(width int, height int, deviceScaleFactor float64, mobile bool, fitWindow bool) error {
+	_, err := remote.SendRequest("Emulation.setDeviceMetricsOverride", Params{
+		"width":  int(width),
+		"height": int(height),
+		"deviceScaleFactor": float64(deviceScaleFactor),
+		"mobile": bool(mobile),
+		"fitWindow": bool(fitWindow)})
+
+	return err
+}
+
 // SetVirtualTimePolicy turns on virtual time for all frames (replacing real-time with a synthetic time source) and sets the current virtual time policy. Note this supersedes any previous time budget.
 func (remote *RemoteDebugger) SetVirtualTimePolicy(policy VirtualTimePolicy, budget int) error {
 	params := Params{"policy": policy}


### PR DESCRIPTION
Hi there! I've added the `Emulate.setDeviceMetricsOverride` call and written an example on how to use this.

It's a bit wonky on google.com, but it has the same behaviour as the one I use on node.js (blog post link:
https://jonathanmh.com/taking-full-page-screenshots-headless-chrome/ ) so I assume it's working correctly.

Chrome DevTools link: https://chromedevtools.github.io/devtools-protocol/tot/Emulation/#method-setDeviceMetricsOverride