### PR TITLE
fix reading responses map without locking

### DIFF
--- a/godet.go
+++ b/godet.go
@@ -346,9 +346,11 @@ func (remote *RemoteDebugger) SendRequest(method string, params Params) (map[str
 
 // sendRawReplyRequest sends a request and returns the reply bytes.
 func (remote *RemoteDebugger) sendRawReplyRequest(method string, params Params) ([]byte, error) {
+	responseChann := make(chan json.RawMessage, 1)
+
 	remote.Lock()
 	reqID := remote.reqID
-	remote.responses[reqID] = make(chan json.RawMessage, 1)
+	remote.responses[reqID] = responseChann
 	remote.reqID++
 	remote.Unlock()
 
@@ -359,7 +361,7 @@ func (remote *RemoteDebugger) sendRawReplyRequest(method string, params Params) 
 	}
 
 	remote.requests <- command
-	reply := <-remote.responses[reqID]
+	reply := <-responseChann
 
 	remote.Lock()
 	delete(remote.responses, reqID)


### PR DESCRIPTION
Came across fatal error of concurrent map read and write when using across goroutines in a production environment.
I used this fix afterwards, should be working.