### PR TITLE
Fix EnableRequestInterception

### DIFF
--- a/godet.go
+++ b/godet.go
@@ -887,11 +887,21 @@ func (remote *RemoteDebugger) GetCookies(urls []string) ([]Cookie, error) {
 
 // EnableRequestInterception enables interception, modification or cancellation of network requests
 func (remote *RemoteDebugger) EnableRequestInterception(enabled bool) error {
-	_, err := remote.SendRequest("Network.enableRequestInterception", Params{
-		"enabled": enabled,
-	})
-
-	return err
+	if enabled {
+		_, err := remote.SendRequest("Network.setRequestInterception", Params{
+			"patterns": []map[string]string{
+				map[string]string{
+					"urlPattern": "*",
+				},
+			},
+		})
+		return err
+	} else {
+		_, err := remote.SendRequest("Network.setRequestInterception", Params{
+			"patterns": []map[string]string{},
+		})
+		return err
+	}
 }
 
 // ContinueInterceptedRequest is the response to Network.requestIntercepted


### PR DESCRIPTION
In recent versions of Chrome Network.enableRequestInterception has been changed to [Network.setRequestInterception](https://chromedevtools.github.io/devtools-protocol/tot/Network#method-setRequestInterception). It is now also possible to specify [options](https://chromedevtools.github.io/devtools-protocol/tot/Network#type-RequestPattern) for which requests should be intercepted. I'm not show how you feel about breaking your API and changing the parameters to EnableRequestInterception or maybe it should be a new function?