### PR TITLE
Fix #27 and #28: avoid panic and mute bogus error messages displayed after Close() is called

### DIFF
--- a/godet.go
+++ b/godet.go
@@ -382,6 +382,9 @@ func (remote *RemoteDebugger) sendRawReplyRequest(method string, params Params) 
 
 func (remote *RemoteDebugger) sendMessages() {
 	for message := range remote.requests {
+		if remote.isClosing {
+			break
+		}
 		bytes, err := json.Marshal(message)
 		if err != nil {
 			log.Println("marshal", message, err)


### PR DESCRIPTION
As stated in https://github.com/raff/godet/issues/28, I'm not sure if this is a proper/desired fix, but it works.