### PR TITLE
added support for Network.getResponseBodyForInterception

### DIFF
--- a/godet.go
+++ b/godet.go
@@ -898,6 +898,20 @@ func (remote *RemoteDebugger) GetResponseBody(req string) ([]byte, error) {
 	}
 }
 
+func (remote *RemoteDebugger) GetResponseBodyForInterception(iid string) ([]byte, error) {
+	res, err := remote.SendRequest("Network.getResponseBodyForInterception", Params{
+		"interceptionId": iid,
+	})
+
+	if err != nil {
+		return nil, err
+	} else if b, ok := res["base64Encoded"]; ok && b.(bool) {
+		return base64.StdEncoding.DecodeString(res["body"].(string))
+	} else {
+		return []byte(res["body"].(string)), nil
+	}
+}
+
 type Cookie struct {
 	Name     string  `json:"name"`
 	Value    string  `json:"value"`


### PR DESCRIPTION
I have been using godep as a way to intercept and modify request and responses while pentesting applications. It would be nice if `Network.getResponseBodyForInterception` was supported. The implementation is almost identical to Network.GetResponseBody, as only the parameter name changes. The  [documentation](https://chromedevtools.github.io/devtools-protocol/tot/Network/#method-getResponseBody) shows that this method is "experimental," but it opens a lot of opportunities for creating security assessment tools. Hopefully you find this useful to integrate with godep 