### PR TITLE
Fix FailRequest

### DIFF
--- a/godet.go
+++ b/godet.go
@@ -1182,7 +1182,7 @@ func (remote *RemoteDebugger) ContinueRequest(requestID string,
 
 // FailRequest causes the request to fail with specified reason.
 func (remote *RemoteDebugger) FailRequest(requestID string, errorReason ErrorReason) error {
-	_, err := remote.SendRequest("Fetch.continueRequest", Params{
+	_, err := remote.SendRequest("Fetch.failRequest", Params{
 		"requestId":   requestID,
 		"errorReason": errorReason,
 	})


### PR DESCRIPTION
This fixes `RemoteDebugger.FailRequest` as it should call `Fetch.failRequest` rather than `Fetch.continueRequest`. You can see this documented at https://chromedevtools.github.io/devtools-protocol/tot/Fetch#method-failRequest