### PR TITLE
Update godet.go

### DIFF
--- a/godet.go
+++ b/godet.go
@@ -661,7 +661,7 @@ func (remote *RemoteDebugger) NewTab(url string) (*Tab, error) {
 		path += "?" + url
 	}
 
-	resp, err := responseError(remote.http.Do(remote.http.Request("GET", path, nil, nil)))
+	resp, err := responseError(remote.http.Do(remote.http.Request("PUT", path, nil, nil)))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Change `GET` -> `PUT` for `/json/new` with the latest chrome update. As using `GET` throws the error: `Using unsafe HTTP verb GET to invoke /json/new. This action supports only PUT verb.`